### PR TITLE
Add gym[atari] Supports in wrapper.py

### DIFF
--- a/surreal/env/wrapper.py
+++ b/surreal/env/wrapper.py
@@ -162,7 +162,7 @@ class MaxStepWrapper(Wrapper):
 class GymAdapter(Wrapper):
     def __init__(self, env, env_config):
         super().__init__(env)
-        assert not env_config.pixel_input, "Pixel input training not supported with OpenAI Gym"
+        #assert not env_config.pixel_input, "Pixel input training not supported with OpenAI Gym"
         assert isinstance(env, gym.Env)
         self.env = env
 


### PR DESCRIPTION
Block the pixel-input assert.
A few codes to walk-through surreal-tmux for gym[atari] supports by forhonourlx on 2019-02-06.