### PR TITLE
Add gym[atari] Supports in ppo_net.py

### DIFF
--- a/surreal/model/ppo_net.py
+++ b/surreal/model/ppo_net.py
@@ -325,10 +325,11 @@ class PPOModel(nnx.Module):
                 output of critic network
         '''
         obs_list = []
-        obs_flat = self._gather_low_dim_input(obs)
-        if self.use_z_filter:
-            obs_flat = self.z_filter.forward(obs_flat)
-        obs_list.append(obs_flat)
+        if 'low_dim' in obs:
+            obs_flat = self._gather_low_dim_input(obs)
+            if self.use_z_filter:
+                obs_flat = self.z_filter.forward(obs_flat)
+            obs_list.append(obs_flat)
 
         if self.if_pixel_input:
             # right now assumes only one camera angle.


### PR DESCRIPTION
Check if 'low_dim' is in obs.
A few codes to walk-through surreal-tmux ppo for gym[atari] discrete action supports by forhonourlx on 2019-02-06.