### PR TITLE
Add gym[atari] Supports in ppo_agent.py

### DIFF
--- a/surreal/agent/ppo_agent.py
+++ b/surreal/agent/ppo_agent.py
@@ -144,6 +144,10 @@ class PPOAgent(Agent):
             action_choice = action_choice.reshape((-1,))
             action_pd     = action_pd.reshape((-1,))
             action_info[1].append(action_pd)
+            
+            if self.env_config.action_spec['type'] == 'discrete':
+                action_choice = np.argmax(action_choice)
+            
             if self.agent_mode != 'training':
                 return action_choice
             else:


### PR DESCRIPTION
if self.env_config.action_spec['type'] == 'discrete':
    action_choice = np.argmax(action_choice)
A few codes to walk-through surreal-tmux ppo for gym[atari] discrete action supports by forhonourlx on 2019-02-06.